### PR TITLE
Introduce hidden preference for initials delimiter

### DIFF
--- a/chrome/content/zotfile/wildcards.js
+++ b/chrome/content/zotfile/wildcards.js
@@ -153,20 +153,21 @@ Zotero.ZotFile.Wildcards = new function() {
         var max_authors = (Zotero.ZotFile.getPref("truncate_authors")) ? Zotero.ZotFile.getPref("max_authors") : 500;
         if (numauthors <= max_authors) add_etal = false;
         else numauthors = Zotero.ZotFile.getPref("number_truncate_authors");
-        var delimiter = Zotero.ZotFile.getPref("authors_delimiter");
+        var authorsDelimiter  = Zotero.ZotFile.getPref("authors_delimiter");
+        var initialsDelimiter = Zotero.ZotFile.getPref("initials_delimiter");
         var j = 0;
         for (i = 0; i < creators.length; ++i) {
             if (j < numauthors && creatorTypeIDs.indexOf(creators[i].creatorTypeID) != -1) {
-                if (author !== "") author += delimiter + creators[i].lastName;
+                if (author !== "") author += authorsDelimiter  + creators[i].lastName;
                 if (author === "") author = creators[i].lastName;
-                var lastf =  creators[i].lastName + creators[i].firstName.substr(0, 1).toUpperCase();
-                if (author_lastf !== "") author_lastf += delimiter + lastf;
+                var lastf =  creators[i].lastName + initialsDelimiter + creators[i].firstName.substr(0, 1).toUpperCase();
+                if (author_lastf !== "") author_lastf += authorsDelimiter  + lastf;
                 if (author_lastf === "") author_lastf = lastf;
-                var initials = creators[i].firstName.substr(0, 1).toUpperCase() + creators[i].lastName.substr(0, 1).toUpperCase()
-                if (author_initials !== "") author_initials += delimiter + initials;
+                var initials = creators[i].firstName.substr(0, 1).toUpperCase() + initialsDelimiter + creators[i].lastName.substr(0, 1).toUpperCase()
+                if (author_initials !== "") author_initials += authorsDelimiter  + initials;
                 if (author_initials === "") author_initials = initials;
         var lastg = creators[i].lastName + ", " + creators[i].firstName;
-                if (author_lastg !== "") author_lastg += delimiter + lastg;
+                if (author_lastg !== "") author_lastg += authorsDelimiter  + lastg;
                 if (author_lastg === "") author_lastg = lastg;
                 j=j+1;
             }
@@ -197,13 +198,13 @@ Zotero.ZotFile.Wildcards = new function() {
         var j = 0;
         for (i = 0; i < creators.length; ++i) {
             if (j < numeditors && editorType.indexOf(creators[i].creatorTypeID) != -1) {
-                if (editor !== "") editor += delimiter + creators[i].lastName;
+                if (editor !== "") editor += authorsDelimiter  + creators[i].lastName;
                 if (editor === "") editor = creators[i].lastName;
-                var lastfe =  creators[i].lastName + creators[i].firstName.substr(0, 1).toUpperCase();
-                if (editor_lastf !== "") editor_lastf += delimiter + lastf;
+                var lastfe =  creators[i].lastName + initialsDelimiter + creators[i].firstName.substr(0, 1).toUpperCase();
+                if (editor_lastf !== "") editor_lastf += authorsDelimiter  + lastf;
                 if (editor_lastf === "") editor_lastf = lastf;
-                var initials = creators[i].firstName.substr(0, 1).toUpperCase() + creators[i].lastName.substr(0, 1).toUpperCase()
-                if (editor_initials !== "") editor_initials += delimiter + initials;
+                var initials = creators[i].firstName.substr(0, 1).toUpperCase() + initialsDelimiter + creators[i].lastName.substr(0, 1).toUpperCase()
+                if (editor_initials !== "") editor_initials += authorsDelimiter  + initials;
                 if (editor_initials === "") editor_initials = initials;
                 j=j+1;
             }

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -18,6 +18,7 @@ pref("extensions.zotfile.number_truncate_authors", 1);
 pref("extensions.zotfile.add_etal", true);
 pref("extensions.zotfile.etal", " et al");
 pref("extensions.zotfile.authors_delimiter", "_");
+pref("extensions.zotfile.initials_delimiter", "");
 pref("extensions.zotfile.removeDiacritics", false);
 pref("extensions.zotfile.removePeriods", false);
 pref("extensions.zotfile.confirmation", true);

--- a/docs/index.md
+++ b/docs/index.md
@@ -250,6 +250,10 @@ Search for `extensions.zotfile` to see a list of the hidden zotfile options. Her
 
     Custom, regular expression-based replacements in extracted annotations. This can be useful because some pdfs contain 'broken' characters. For example, [{"regex":" ?\u00f0", "replacement": " ("}] replaces the unicode character ð with ( to fix a problem in pdfs from a certain publisher. In this case, ð is a problem with the pdf and not with zotfile's extraction. The hidden option can be used to fix it.
 
+-   `.initials_delimiter`
+
+     Custom string to insert between initials or between lastname and initials, when author/editor wildcards using initials are used. The default is blank. For example, specifying "," as the delimiter will make %F return "Ada,L" instead of "AdaL", and %I return "A,L" instead of "AL". Please note that using certain characters might not be compatible with your filesystem and/or cloud storage. 
+
 ### REPORTING A BUG
 
 You can report bugs on the [Zotfile thread](http://forums.zotero.org/discussion/5301/6/zotfile-zotero-plugin-to-rename-move-and-attach-pdfs-send-them-to-ipad-extract-pdf-annotations/) in the Zotero forum. Please provide information about about your system (Windows, Mac OS, Linux etc) as well as your Zotfile, Zotero and Firefox version. Also make sure that you can reproduce the bug and describe the steps as closely as possible. In addition, any information from the Error Console are very helpful. You can check the Error Console in Zotero by going to 'Help -> Report Errors to Zotero...' (do not follow the steps, just look at report content). For zotfile bugs,  the 'Source File' should be something like `chrome://zotfile/content/...` (most likely zotfile.js). You can also clear the console, execute the actions that caused the problem and then check again. If I ask you to provide a Report ID, follow the instructions [here](http://www.zotero.org/support/reporting_bugs).


### PR DESCRIPTION
Introduce custom string to insert between initials or between lastname and initials, when author/editor wildcards using initials are used. The default is blank. For example, specifying "," as the delimiter will make %F return "Ada,L" instead of "AdaL", and %I return "A,L" instead of "AL".